### PR TITLE
klein_df.columns output

### DIFF
--- a/_episodes/02-manipulating-data.md
+++ b/_episodes/02-manipulating-data.md
@@ -68,8 +68,9 @@ klein_df.columns
 
 ~~~
 Index(['Title', 'Identifier', 'Local Identifier 1', 'Date 1', 'People',
-       'Subject (Name) 1', 'Subject (Name) 2', 'Subject (Name) 3',
-       'Subject (Name) 4', 'Subject (Name) 5'],
+       'Creator', 'Type', 'Form/Genre 1', 'Subject (Name) 1',
+       'Subject (Name) 2', 'Subject (Name) 3', 'Subject (Name) 4',
+       'Subject (Name) 5'],
       dtype='object')
 ~~~
 {: .output}


### PR DESCRIPTION
I'm running through this, and the output to klein_df.columns includes `Creator`, `Type`, and `Form/Genre 1`, which aren't reflected in the lesson's current output for that section.